### PR TITLE
Update argument slicer

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ client.once('disconnect', () => {
 });
 
 client.on('message', async message => {
-	const args = message.content.slice(1).split(/ +/);
+	const args = message.content.slice(prefix.length).split(/ +/);
 	const commandName = args.shift().toLowerCase();
 	const command = client.commands.get(commandName);
 


### PR DESCRIPTION
The prefix was removed using the assumption that it would only be one character long. 
Prefixes like "++" would cause the bot to error out.
This makes a simple check for the length of the prefix before slicing.