### PR TITLE
No prefix command is not needed in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,3 @@
 {
-    "prefix": "!",
     "token": "YOUR_TOKEN"
 }


### PR DESCRIPTION
Prefix command in config.json file is not needed because " **!** " commands support has been removed from this bot only "!deploy" is used after invitation in server. Now onwards it is using " **/** " notation eg- /play .....