### PR TITLE
Added volume command

### DIFF
--- a/commands/volume.js
+++ b/commands/volume.js
@@ -7,7 +7,7 @@ module.exports = {
     {
       name: 'volume',
       type: 4, // 'INTEGER' Type
-      description: 'Volume from 0-100',
+      description: 'Number between 0-200',
       required: true,
     },
   ],
@@ -38,7 +38,7 @@ module.exports = {
 
     var volume = interaction.options.get('volume').value;
     volume = Math.max(0, volume);
-    volume = Math.min(100, volume);
+    volume = Math.min(200, volume);
     const success = queue.setVolume(volume);
 
     return void interaction.followUp({

--- a/commands/volume.js
+++ b/commands/volume.js
@@ -1,0 +1,48 @@
+const {GuildMember} = require('discord.js');
+
+module.exports = {
+  name: 'volume',
+  description: 'Change the volume!',
+  options: [
+    {
+      name: 'volume',
+      type: 4, // 'INTEGER' Type
+      description: 'Volume from 0-100',
+      required: true,
+    },
+  ],
+  async execute(interaction, player) {
+    if (!(interaction.member instanceof GuildMember) || !interaction.member.voice.channel) {
+      return void interaction.reply({
+        content: 'You are not in a voice channel!',
+        ephemeral: true,
+      });
+    }
+
+    if (
+      interaction.guild.me.voice.channelId &&
+      interaction.member.voice.channelId !== interaction.guild.me.voice.channelId
+    ) {
+      return void interaction.reply({
+        content: 'You are not in my voice channel!',
+        ephemeral: true,
+      });
+    }
+
+    await interaction.deferReply();
+    const queue = player.getQueue(interaction.guildId);
+    if (!queue || !queue.playing)
+      return void interaction.followUp({
+        content: '❌ | No music is being played!',
+      });
+
+    var volume = interaction.options.get('volume').value;
+    volume = Math.max(0, volume);
+    volume = Math.min(100, volume);
+    const success = queue.setVolume(volume);
+
+    return void interaction.followUp({
+      content: success ? `🔊 | Volume set to ${volume}!` : '❌ | Something went wrong!',
+    });
+  },
+};


### PR DESCRIPTION
This adds a command to set the volume between 0-200 on the queue.

Note that this will only set the volume on the current queue — it will reset to 100 when the queue is finished. 

Perhaps storing the volume and then setting it on play would be ideal (would have to be per guild, right?). If you have any idea of the correct way to go about this I can give it a try sometime. If not, no worries.