### PR TITLE
Add docker-compose file to discord bot

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,9 @@
+version: '3.3'
+
+services:
+  discord-bot:
+    build:
+        context: ./
+        dockerfile: Dockerfile
+    container_name: discord-bot
+    restart: always


### PR DESCRIPTION
Add `docker-compose` file to discord bot to enable easier Docker deployments.