### PR TITLE
feat: move discord token to env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.env

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ cd discord-bot/
 
 # Install the dependencies
 npm install
+
+# Configure Discord Bot Token
+echo "DISCORD_TOKEN='INSERT_YOUR_TOKEN_HERE'" > .env
 ```
 
 ### Required permissions

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cd discord-bot/
 npm install
 
 # Configure Discord Bot Token
-echo "DISCORD_TOKEN='INSERT_YOUR_TOKEN_HERE'" > .env
+ echo "DISCORD_TOKEN='INSERT_YOUR_TOKEN_HERE'" > .env
 ```
 
 ### Required permissions

--- a/config.json
+++ b/config.json
@@ -1,5 +1,4 @@
 {
-    "token": "YOUR_TOKEN",
     "activityType": "PLAYING",
     "activity": "your music selections"
 }

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 const fs = require('fs');
 const Discord = require('discord.js');
 const Client = require('./client/Client');
@@ -96,4 +98,4 @@ client.on('interactionCreate', async interaction => {
   }
 });
 
-client.login(config.token);
+client.login(process.env.DISCORD_TOKEN);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@discordjs/opus": "^0.8.0",
         "discord-player": "^5.3.2",
         "discord.js": "^14.6.0",
+        "dotenv": "^16.0.3",
         "ffmpeg": "0.0.4",
         "fluent-ffmpeg": "^2.1.2",
         "ytdl-core": "^4.11.0"
@@ -479,6 +480,14 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/emoji-regex": {
@@ -1660,6 +1669,11 @@
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.1"
       }
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@discordjs/opus": "^0.8.0",
     "discord-player": "^5.3.2",
     "discord.js": "^14.6.0",
+    "dotenv": "^16.0.3",
     "ffmpeg": "0.0.4",
     "fluent-ffmpeg": "^2.1.2",
     "ytdl-core": "^4.11.0"


### PR DESCRIPTION
Seen a few too many forks committing their config.json with their secret discord token to github.
Small fix to make that a bit easier, by default users won't do it accidentally unless they edit .gitignore