### PR TITLE
Fix activityType

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "activityType": "0",
+    "activityType": 0,
     "activity": "your music selections"
 }


### PR DESCRIPTION
Default config sets activityType as a string, so presence won't work