### PR TITLE
feat: add docker build github action

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,31 @@
+name: docker build
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/TannerGabriel/discord-bot:latest

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ A mutliarch docker image for `amd64` and `arm64` based on the main branch is ava
 docker pull ghcr.io/TannerGabriel/discord-bot:latest
 ```
 
-A Github Action automatically builds and push `amd64` and `arm64` to ghcr.io, all builds are based on the master branch.
+A Github Action automatically builds and push `amd64` and `arm64` to ghcr.io, all builds are based on the main branch.
 
 Only `:latest` tag is supported, otherwise use SHA256 from https://github.com/TannerGabriel/discord-bot/pkgs/container/discord-bot for pinning to a specific commit.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ You can find the tutorial about building a discord music bot [here](https://gabr
 
 * [Requirements](#requirements)
 * [Getting started](#getting-started)
+* [Docker](#docker)
 * [Features & Commands](#features--commands)
 * [Common errors](#common-errors)
 * [Contributing](#contributing)
@@ -80,6 +81,18 @@ Before you can use the bots slash command you first need to add them to your Dis
 After deploying the commands you should be able to see and access them by typing a slash:
 
 <img src="./assets/commands.png">
+
+## Docker
+
+A mutliarch docker image for `amd64` and `arm64` based on the main branch is available from Github Container Registry:
+
+```bash
+docker pull ghcr.io/TannerGabriel/discord-bot:latest
+```
+
+A Github Action automatically builds and push `amd64` and `arm64` to ghcr.io, all builds are based on the master branch.
+
+Only `:latest` tag is supported, otherwise use SHA256 from https://github.com/TannerGabriel/discord-bot/pkgs/container/discord-bot for pinning to a specific commit.
 
 ## Features & Commands
 


### PR DESCRIPTION
Adds a Github Action for building docker images for amd64 and arm64, and uploading image to ghcr.io.

Docker users can then use the following command to pull the latest image from the main branch:

```
docker pull ghcr.io/TannerGabriel/discord-bot:latest
```

Would require granting github actions read and write permissions in the repo settings, as it writes to github container registry.

![image](https://user-images.githubusercontent.com/29174850/217540770-a12bb125-ba50-4586-bfcc-65f16836d9dc.png)
