### PR TITLE
Switch Dockerfile to distroless base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM node:18 AS build
 WORKDIR /app
 COPY . /app
+COPY --from=mwader/static-ffmpeg:5.1.2 /ffmpeg /ffmpeg
 RUN npm ci --omit=dev
+RUN apt update && \
+    apt install -y upx && \
+    upx -1 /ffmpeg
 
 FROM gcr.io/distroless/nodejs18
 WORKDIR /app
 COPY --from=build /app /app
-COPY --from=mwader/static-ffmpeg:5.1.2 /ffmpeg /bin/
+COPY --from=build /ffmpeg /bin/
 USER nonroot
 CMD [ "index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
-FROM node:17.4.0
+FROM node:18 AS build
+WORKDIR /app
+COPY . /app
+RUN npm ci --omit=dev
 
-WORKDIR /usr/src/app
-
-RUN apt-get update || : && apt-get install python -y
-RUN apt-get install ffmpeg -y
-
-COPY package*.json ./
-
-RUN npm ci
-
-COPY . .
-
-CMD [ "node", "index.js" ]
+FROM gcr.io/distroless/nodejs18
+WORKDIR /app
+COPY --from=build /app /app
+COPY --from=mwader/static-ffmpeg:5.1.2 /ffmpeg /bin/
+USER nonroot
+CMD [ "index.js" ]


### PR DESCRIPTION
This updates the Dockerfile to use the [distroless Node.js](https://github.com/GoogleContainerTools/distroless/tree/main/nodejs) 18 image from Google.
For this to work, a static build of ffmpeg ist used from [mwader/static-ffmpeg](https://hub.docker.com/r/mwader/static-ffmpeg) which is then compresses with upx.

