### PR TITLE
fix: Docker build action

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   docker:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -28,4 +28,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/TannerGabriel/discord-bot:latest
+            ghcr.io/tannergabriel/discord-bot:latest


### PR DESCRIPTION
## This PR

- Change the repo name to lowercase to fix the error: `repository name must be lowercase`
- Add `workflow_dispatch` so that the action can be run manually