### PR TITLE
fix: Bot not disconnecting after queue finished

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@ const Client = require('./client/Client');
 const config = require('./config.json');
 const {Player} = require('discord-player');
 
-const {ActivityType} = require('discord.js');
-
 const client = new Client();
 client.commands = new Discord.Collection();
 
@@ -62,6 +60,8 @@ player.events.on('emptyChannel', queue => {
 
 player.events.on('emptyQueue', queue => {
     queue.metadata.channel.send('✅ | Queue finished!');
+    // Delete queue and disconnect from voice channel
+    queue.delete();
 });
 
 player.events.on('error', (queue, error) => {


### PR DESCRIPTION
Delete queue when receiving the `emptyQueue` event so that the bot disconnects from the voice channel.