### PR TITLE
fix: queue null check & queue track listing

### DIFF
--- a/commands/queue.js
+++ b/commands/queue.js
@@ -12,19 +12,27 @@ module.exports = {
         }
 
         const queue = useQueue(interaction.guild.id)
-        if (typeof (queue) != 'undefined') {
+        if (queue != null) {
             const trimString = (str, max) => ((str.length > max) ? `${str.slice(0, max - 3)}...` : str);
+            
+            let queueStr = `🎶 |  **Upcoming Songs:**\n`
+
+            // Build queue list
+            queue.tracks.data.forEach((track, index) => {
+            queueStr += `${index + 1}. ${track.title} - ${track.author}\n`;
+            });
+
             return void interaction.reply({
                 embeds: [
                     {
-                        title: 'Now Playing',
-                        description: trimString(`The Current song playing is 🎶 | **${queue.currentTrack.title}**! \n 🎶 | ${queue}! `, 4095),
+                        title: `Now Playing 🎶 |  **${queue.currentTrack.title}**`,
+                        description: trimString(queueStr, 4095),
                     }
                 ]
             })
         } else {
             return void interaction.reply({
-                content: 'There is no song in the queue!'
+                content: 'There are no songs in the queue!'
             })
         }
     }


### PR DESCRIPTION
**Queue Check Bug:**
When running the queue command before any tracks are added, it would encounter an exception:

    TypeError: Cannot read properties of null (reading 'currentTrack')

Replaced the undefined check with a broader null check, now correctly returns that there are no songs.
![image](https://github.com/TannerGabriel/discord-bot/assets/24445283/c970a4fe-9463-4d0d-b0f6-eeecd13525da)


**Queue List Bug:**
When listing the queue, it now returns just `[object Object]`
![image](https://github.com/TannerGabriel/discord-bot/assets/24445283/4241a3b8-20b4-49fd-985d-7b535679f5da)

Refactored to iterate track list and display:
![image](https://github.com/samdammers/discord-bot/assets/24445283/d7f07724-8333-406a-a183-594c6922626a)

