### PR TITLE
Check for permission on purge

### DIFF
--- a/commands/purge.js
+++ b/commands/purge.js
@@ -12,6 +12,10 @@ module.exports = {
     async execute(interaction) {
         const deleteCount = interaction.options.get('num').value;
 
+        if (!interaction.member.permissions.has('MANAGE_MESSAGES')) {
+            return interaction.reply("I can't purge these messages.");
+        }
+
         if (!deleteCount || deleteCount < 2 || deleteCount > 100) {
             return void interaction.reply({
                 content: `Please provide a number between 2 and 100 for the number of messages to delete`,


### PR DESCRIPTION
This change will check for the manage messages permission when a person uses the purge command.